### PR TITLE
define config relay bot nick and nickserv

### DIFF
--- a/src/sortinghat.nim
+++ b/src/sortinghat.nim
@@ -30,6 +30,7 @@ let
 
 
 var authPass: string
+var relayBot: string
 
 type
   FormattedResponse = string
@@ -51,7 +52,7 @@ proc answerQuizQuestion(client: Irc, e: IrcEvent, nick: string, index: int)
 
 proc handleMsg(client: Irc, e: IrcEvent) =
   echo e.raw
-  if e.text == "If you do not change within 1 minute, I will change your nick." and authPass.len > 0:
+  if e.text == "If you do not change within 1 minute, I will change your nick." and authPass.len > 0 and e.nick == "NickServ":
     client.privmsg("NickServ", fmt"IDENTIFY {authPass}")
 
   if e.cmd == MPrivMsg:
@@ -59,7 +60,7 @@ proc handleMsg(client: Irc, e: IrcEvent) =
       nick = e.nick
       message = e.text
 
-    if e.text.match(isBotUserCommandRegex):
+    if e.text.match(isBotUserCommandRegex) and nick == relayBot:
       let split = e.text.split("> ", 1)
       nick = split[0][1..^1]
       message = split[1]


### PR DESCRIPTION
it would seem someone can spoof as a nick on a relay. not a major problem, but can be annoying.
also the way it listened for NickServ to ask for a password doesn't verify if the sender is from NickServ, even though it would only ever send the password to NickServ